### PR TITLE
Fixes to make this package work in any Laravel project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ return [
 ];
 ```
 
+### Models Namespace
+
+If you models are in a custom namespace different from `app_namespace`, you can specify this config.
+
+```
+<?php
+
+return [
+    'models_namespace' => 'SomethingElse'
+];
+```
+
 ### Mapping
 
 To add a resource to the default controller, you just have to add a line in the `/config/api.php` file:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Install the package via composer:
 First, add the eloquence service provider to your config/app.php file:
 
     'Osedea\LaravelRest\LaravelRestServiceProvider'
+    
+All you models need to use the trait `\Osedea\LaravelRest\Traits\CommandModel` to provide some attributes and methods:
+
+```
+<?php
+
+namespace Acme;
+
+class SomeModel {
+    use \Osedea\LaravelRest\Traits\CommandModel;
+}
+
+```
 
 Then, publish the config file to your application:
 

--- a/src/Commands/DefaultCommand/IndexCommand.php
+++ b/src/Commands/DefaultCommand/IndexCommand.php
@@ -29,7 +29,6 @@ class IndexCommand extends Command implements SelfHandling
         $perPage = $this->getPerPageFromModelClass($class);
         $fields = $this->getFieldsFromRequest();
 
-
         $query = $class::withRequestSort()->withRequestEmbed();
         $query = $this->addWhereStatements($query, $class);
 

--- a/src/Services/TranslatorService.php
+++ b/src/Services/TranslatorService.php
@@ -17,11 +17,12 @@ class TranslatorService
      *
      * @param string $resource
      * @return string
+     * @throws NotFoundHttpException
      */
     public function getClassFromResource($resource)
     {
-        // This is the namespace used for the app
-        $namespace = Config::get('api.app_namespace');
+        // This is the models namespace
+        $modelsNamespace = Config::get('api.models_namespace', Config::get('api.app_namespace'));
 
         // This array contains mapping between resources and Model classes
         $mapping = Config::get('api.mapping');
@@ -34,7 +35,7 @@ class TranslatorService
             throw new NotFoundHttpException;
         }
 
-        return implode('\\', [$namespace, 'Models', $mapping[$resource]]);
+        return implode('\\', [$modelsNamespace, $mapping[$resource]]);
     }
 
     /**
@@ -48,6 +49,7 @@ class TranslatorService
      * @param string $action
      * @param string|null $relation
      * @return string
+     * @throws NotFoundHttpException
      */
     public function getCommandFromResource($resource, $action, $relation = null)
     {
@@ -71,9 +73,19 @@ class TranslatorService
                 throw new NotFoundHttpException('The resource [' . $resource . '] is not mapped to any Model.');
             }
 
-            $command = implode('\\', [$namespace, 'Commands', $mapping[$resource] . 'Command', ucfirst($mapping[$relation]) . ucfirst($action) . 'Command']);
+            $command = implode('\\', [
+                $namespace,
+                'Commands',
+                $mapping[$resource] . 'Command',
+                ucfirst($mapping[$relation]) . ucfirst($action) . 'Command'
+            ]);
         } else {
-            $command = implode('\\', [$namespace, 'Commands', $mapping[$resource] . 'Command', ucfirst($action) . 'Command']);
+            $command = implode('\\', [
+                $namespace,
+                'Commands',
+                $mapping[$resource] . 'Command',
+                ucfirst($action) . 'Command'
+            ]);
         }
 
         // If no custom command is found, then we use one of the default ones

--- a/src/Traits/CommandModel.php
+++ b/src/Traits/CommandModel.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Osedea\LaravelRest\Traits;
+
+trait CommandModel
+{
+    /*
+         * The attributes that can be used for filtering through the API.
+         *
+         * @var array
+         */
+    public static $filterable = [];
+
+    /**
+     * This holds the maximum number of items per page fot this model.
+     * @var integer
+     */
+    protected $perPageMax = 25;
+
+    public function getPerPageMax()
+    {
+        return $this->perPage;
+    }
+
+    public function setPerPageMax($perPageMax)
+    {
+        $this->perPageMax = $perPageMax;
+    }
+
+    /**
+     * This scope automatically sorts a query depending on the request.
+     * A request looks like this:
+     *      - Sort by [column ASC]:                     ?sort=column
+     *      - Sort by [column DESC]:                    ?sort=-column
+     *      - Sort by [column1 ASC] and [column2 DESC]: ?sort=column1,-column2
+     *
+     * @param $query
+     * @return mixed
+     */
+    public function scopeWithRequestSort($query)
+    {
+        if (($sorts = \Request::get('sort', false))) {
+            // We list all sorting options
+            $sorts = explode(',', $sorts);
+
+            foreach ($sorts as $sort) {
+                $order = 'asc';
+
+                // If the first character is a dash (-), then the sort order is reversed
+                if (substr($sort, 0, 1) === '-') {
+                    $order = 'desc';
+
+                    // We need to remove the dash from the sort because it is used in the orderBy method.
+                    $sort = substr($sort, 1, strlen($sort));
+                }
+
+                $query->orderBy($sort, $order);
+            }
+        }
+
+        return $query;
+    }
+
+    public function scopeWithRequestEmbed($query)
+    {
+        if (($embeds = \Request::get('embed', false))) {
+            $embeds = explode(',', $embeds);
+
+            $query->with($embeds);
+        }
+
+        return $query;
+    }
+}

--- a/src/config/api.php
+++ b/src/config/api.php
@@ -16,6 +16,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Models Namespace
+    |--------------------------------------------------------------------------
+    |
+    | The Eloquent models namespace. This has to be the namespace from the
+    | root of the project.
+    | If not specified, then `app_namespace` will be used instead.
+    |
+    */
+
+    'models_namespace' => 'App',
+
+    /*
+    |--------------------------------------------------------------------------
     | API Mapping
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Currently this package is missing some code to work on any Laravel project. I updated it but it introduces a breaking change, which is why I made a PR.

With these changes you'll need to do 2 changes:

Add this bloc in the config file:

``` php
    /*
    |--------------------------------------------------------------------------
    | Models Namespace
    |--------------------------------------------------------------------------
    |
    | The Eloquent models namespace. This has to be the namespace from the
    | root of the project.
    | If not specified, then `app_namespace` will be used instead.
    |
    */

    'models_namespace' => 'App\Models',
```

And use the `Osedea\LaravelRest\Traits\CommandModel` trait instead of putting the code in the project base model. It'll work without the trait if the base model has the same code but it won't get updates in the future so it might be good to switch.

I'll push a new version once everybody is aware of these changes.
