### PR TITLE
Add default StoreCommand and UpdateCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ return [
 ];
 ```
 
+### APi Middleware
+
+If you routes need to have a middleware set up, you can specify the middlewares
+or filters to use.
+
+```
+<?php
+
+return [
+    'middleware' => []
+];
+```
+
+
 If you don't specify the key prefix, it will default to `api`.
 
 ## Commands and the default controller

--- a/README.md
+++ b/README.md
@@ -154,19 +154,22 @@ LaravelRest has default commands for several actions:
 
  * `GET /{resource}`: `Osedea\LaravelRest\Commands\DefaultCommand\IndexCommand`
  * `GET /{resource}/{id}`: `Osedea\LaravelRest\Commands\DefaultCommand\ShowCommand`
+ * `POST /{resource}/{id}`: `Osedea\LaravelRest\Commands\DefaultCommand\StoreCommand`
+ * `PUT /{resource}/{id}`: `Osedea\LaravelRest\Commands\DefaultCommand\UpdateCommand`
  * `DELETE /{resource}/{id}`: `Osedea\LaravelRest\Commands\DefaultCommand\DeleteCommand`
  * `GET /{resource}/{id}/{relation}`: `Osedea\LaravelRest\Commands\DefaultCommand\RelationIndexCommand`
 
 With these defaults, the mapping is enough for them to work. You can override them by creating a command using the
 correct namespace:
 
-Example, to override the `POST /users/{id}` default command, create one called `Osedea\LaravelRest\Commands\UserCommand\DestroyCommand`.
+Example, to override the `POST /users/{id}` default command, create one called `Osedea\LaravelRest\Commands\UserCommand\StoreCommand`.
 
 #### Create and Update
 
-Those actions are very specific to a resource so there is no default.
+Those actions are very specific to a resource so the default commands may not fulfill your needs.
+If you want to use the default commands then your models need to have the `$fillable` property set.
 
-You will have to create them for all resources listed in the mapping file. The schema is this:
+To override the default behaviour you will have to create a command for all resources listed in the mapping file. The schema is this:
 
 `Osedea\LaravelRest\Commands\{mapping[resource]}Command\{action}Command`
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ return [
 ];
 ```
 
-### APi Middleware
+If you don't specify the key prefix, it will default to `api`.
+
+### API Middleware
 
 If you routes need to have a middleware set up, you can specify the middlewares
 or filters to use.
@@ -97,9 +99,6 @@ return [
     'middleware' => []
 ];
 ```
-
-
-If you don't specify the key prefix, it will default to `api`.
 
 ## Commands and the default controller
 

--- a/src/Commands/DefaultCommand/StoreCommand.php
+++ b/src/Commands/DefaultCommand/StoreCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Osedea\LaravelRest\Commands\DefaultCommand;
+
+use Request;
+use ReflectionClass;
+use Illuminate\Contracts\Bus\SelfHandling;
+use Osedea\LaravelRest\Commands\Command;
+
+class StoreCommand extends Command implements SelfHandling
+{
+    public $modelClass;
+
+    public function __construct($modelClass)
+    {
+        $this->modelClass = $modelClass;
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $class = $this->modelClass;
+        $mock = new $class();
+
+        $reflection = new ReflectionClass($class);
+        $property = $reflection->getProperty('fillable');
+        $property->setAccessible(true);
+        $fillable = $property->getValue($mock);
+
+        $input = Request::only($fillable);
+
+        $model = $class::create($input);
+        $model->save();
+
+        return $model;
+    }
+}

--- a/src/Commands/DefaultCommand/UpdateCommand.php
+++ b/src/Commands/DefaultCommand/UpdateCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Osedea\LaravelRest\Commands\DefaultCommand;
+
+use Request;
+use ReflectionClass;
+use Illuminate\Contracts\Bus\SelfHandling;
+use Osedea\LaravelRest\Commands\Command;
+
+class UpdateCommand extends Command implements SelfHandling
+{
+    public $modelClass;
+    public $id;
+
+    public function __construct($modelClass, $id)
+    {
+        $this->modelClass = $modelClass;
+        $this->id = $id;
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function handle()
+    {
+        $class = $this->modelClass;
+        $model = $class::findOrFail($this->id);
+
+        $reflection = new ReflectionClass($class);
+        $property = $reflection->getProperty('fillable');
+        $property->setAccessible(true);
+        $fillable = $property->getValue($model);
+
+        $input = $this->removeNullFields(Request::only($fillable));
+
+        return $model->update($input);
+    }
+
+    /**
+     * Removes the null fields of the given array but does not remove the empty
+     * ones. This is useful to clean the request input data so the update
+     * process can do partial updates without issues.
+     *
+     * @param array $fields
+     * @return array
+     */
+    public function removeNullFields(array $fields)
+    {
+        $cleanFields = [];
+
+        foreach ($fields as $field => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            $cleanFields[$field] = $value;
+        }
+
+        return $cleanFields;
+    }
+}

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -36,10 +36,8 @@ abstract class Controller extends BaseController
      * @param int $code
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function success($data, $code = 200)
+    public function success($data, $code = 200, $headers = [])
     {
-        $headers = [];
-
         if ($data instanceof Paginator && $data instanceof LengthAwarePaginator) {
             $headers['X-Total-Count'] = $data->total();
             $headers['X-Total-Pages'] = $data->lastPage();

--- a/src/Http/Controllers/DefaultRestController.php
+++ b/src/Http/Controllers/DefaultRestController.php
@@ -133,7 +133,10 @@ class DefaultRestController extends Controller
 
         $this->runBeforeCommands($command);
 
-        $data = $this->dispatchFrom($command, $request);
+        $data = $this->dispatchFrom($command, $request, [
+            'modelClass' => $this->translator->getClassFromResource($resource),
+            'id' => $id,
+        ]);
 
         $this->fireEventForResource($resource, 'update', $data);
 

--- a/src/Http/Controllers/DefaultRestController.php
+++ b/src/Http/Controllers/DefaultRestController.php
@@ -2,6 +2,7 @@
 
 namespace Osedea\LaravelRest\Http\Controllers;
 
+use Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Http\Request;
 
@@ -81,11 +82,17 @@ class DefaultRestController extends Controller
 
         $this->runBeforeCommands($command);
 
-        $data = $this->dispatchFrom($command, $request);
+        $data = $this->dispatchFrom($command, $request, [
+            'modelClass' => $this->translator->getClassFromResource($resource),
+        ]);
 
         $this->fireEventForResource($resource, 'store', $data);
 
-        return $this->success($data, 201);
+        $newResourceLocation = '/' . Config::get('api.prefix', 'api')
+            . '/' . $resource
+            . '/' . $data->id;
+
+        return $this->success([], 201, ['Location' => $newResourceLocation]);
     }
 
     /**

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -8,8 +8,15 @@ use Illuminate\Support\Facades\Config;
 |--------------------------------------------------------------------------
 |
 */
+$options = [
+    'prefix' => Config::get('api.prefix', 'api'),
+];
 
-Route::group(['prefix' => Config::get('api.prefix', 'api')], function () {
+if (Config::has('api.middleware')) {
+    $options['middleware'] = Config::get('api.middleware');
+}
+
+Route::group($options, function () {
     // These routes are using the api.php config file to map {resource} and {relation} to Models
     Route::get('/{resource}', 'DefaultRestController@index');
     Route::get('/{resource}/{id}', 'DefaultRestController@show');

--- a/src/Traits/CommandModel.php
+++ b/src/Traits/CommandModel.php
@@ -4,18 +4,18 @@ namespace Osedea\LaravelRest\Traits;
 
 trait CommandModel
 {
-    /*
-         * The attributes that can be used for filtering through the API.
-         *
-         * @var array
-         */
+    /**
+     * The attributes that can be used for filtering through the API.
+     *
+     * @var array
+     */
     public static $filterable = [];
 
     /**
      * This holds the maximum number of items per page fot this model.
      * @var integer
      */
-    protected $perPageMax = 25;
+    protected $perPageMax = 50;
 
     public function getPerPageMax()
     {

--- a/src/config/api.php
+++ b/src/config/api.php
@@ -50,6 +50,17 @@ return [
     |
     */
 
-    'prefix' => 'api/v1'
+    'prefix' => 'api/v1',
 
+    /*
+    |--------------------------------------------------------------------------
+    | API Middleware
+    |--------------------------------------------------------------------------
+    |
+    | If your API routes need to use a middleware or filter, specify them here.
+    | However it will apply for all of them.
+    |
+    */
+
+    'middleware' => [],
 ];


### PR DESCRIPTION
Hello, I've just added this default commands, these are matching a very simple implementation that I'll use in a project I'm working on. I'm not taking into account field validation, I think later can be added by telling to the user to specify `$rules` array in the model and as the name says these are just default implementations, is up to the user write it's own implementation to satisfy his needs.

I've tried to follow best REST practices but I don't know if it's ok, i.e when creating a new resource (POST) a 201 is returned with no body and the `Location` header set, however I don't know if the `Location` header value can be a simple uri (`/resource/id`) or it needs to be a complete url (`http://...`).

Another thing I don't know is what body does the response from a PUT request needs to have? I just returned the `$model->update()`, but I don't know if the resource should be returned or if the body needs to be empty.

What do you think?

Thanks.
